### PR TITLE
Use `dl.depot.dev` to download `machine-agent`

### DIFF
--- a/user-data.sh.tftpl
+++ b/user-data.sh.tftpl
@@ -3,7 +3,7 @@ set -e
 exec > >(tee /var/log/user-data.log | logger -t user-data -s 2>/dev/console) 2>&1
 
 # Install latest machine-agent
-wget -O /tmp/machine-agent.tar.gz "https://depot.dev/api/machine-agent/download/linux/$(uname -m)/latest"
+wget -O /tmp/machine-agent.tar.gz "https://dl.depot.dev/machine-agent/download/linux/$(uname -m)/latest"
 tar -zxf /tmp/machine-agent.tar.gz --strip-components=1 --directory /usr/bin bin/machine-agent
 /usr/bin/machine-agent --version
 


### PR DESCRIPTION
Uses the new `dl.depot.dev` to download the `machine-agent`