### PR TITLE
Allow cloud-agent to restart itself to pick up minor upgrades

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -21,7 +21,7 @@ variable "availability-zone" {
 variable "cloud-agent-version" {
   type        = string
   description = "Version tag for ghcr.io/depot/cloud-agent container"
-  default     = "2.2.2"
+  default     = "2"
 }
 
 variable "create" {


### PR DESCRIPTION
Allows the cloud-agent to stop its own task, which causes ECS to recreate the task.