### PR TITLE
Add `tag_specifications` to propagate tags to instances & volumes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -178,6 +178,17 @@ resource "aws_launch_template" "x86" {
   placement {
     availability_zone = var.availability-zone
   }
+
+  tag_specifications = [
+    {
+      resource_type = "instance"
+      tags          = var.tags
+    },
+    {
+      resource_type = "volume"
+      tags          = var.tags
+    },
+  ]
 }
 
 resource "aws_launch_template" "arm" {
@@ -214,6 +225,17 @@ resource "aws_launch_template" "arm" {
   placement {
     availability_zone = var.availability-zone
   }
+
+  tag_specifications = [
+    {
+      resource_type = "instance"
+      tags          = var.tags
+    },
+    {
+      resource_type = "volume"
+      tags          = var.tags
+    },
+  ]
 }
 
 # cloud-agent ECS Task


### PR DESCRIPTION
This is to allow propagating custom tags to the instances and volumes via the launch template `tag_specifications`. I'm not certain this will work as `cloud-agent` sets tags as well, and I doubt the EC2 API merges the two blocks. 