### PR TITLE
Make retention for cloudwatch logs an optional parameter

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -381,7 +381,7 @@ resource "aws_iam_role" "cloud-agent" {
 resource "aws_cloudwatch_log_group" "connection" {
   count             = var.create ? 1 : 0
   name              = "depot-connection-${var.connection-id}"
-  retention_in_days = 7
+  retention_in_days = var.cloud-agent-log-retention
 }
 
 resource "aws_ssm_parameter" "connection-token" {

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,12 @@ variable "cloud-agent-version" {
   default     = "2"
 }
 
+variable "cloud-agent-log-retention" {
+  type        = number
+  description = "Number of days to keep cloudwatch logs for the cloud-agent"
+  default     = 7
+}
+
 variable "create" {
   type        = bool
   description = "Controls if Depot connection resources should be created"


### PR DESCRIPTION
This makes the CloudWatch log retention a parameter that can be configured per connection.