### PR TITLE
Allow permission to modify own ECS cluster

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -353,7 +353,7 @@ resource "aws_iam_role" "cloud-agent" {
         },
 
         {
-          Action    = ["ecs:ListTasks", "ecs:DescribeTasks", "ecs:StopTask"],
+          Action    = ["ecs:*"],
           Effect    = "Allow",
           Resource  = ["*"],
           Condition = { ArnEquals = { "ecs:cluster" = aws_ecs_cluster.cloud-agent[0].arn } }


### PR DESCRIPTION
Needed for self-updates, now that ECS pins the image digest on deploy and so `StopTask` no longer updates the task's container version.