### PR TITLE
Fix typo in ExternalId condition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -233,7 +233,7 @@ resource "aws_iam_role" "control-plane" {
       Principal = { AWS = "375021575472" }
       Condition = {
         StringEquals = {
-          "aws:ExternalId" = var.connection-id
+          "sts:ExternalId" = var.connection-id
         }
       }
     }]


### PR DESCRIPTION
The condition was checking the nonexistent `aws:ExternalId` value instead of `sts:ExternalId`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line Terraform change to the IAM trust policy condition key; primary risk is affecting cross-account role assumption if the external ID expectation differs.
> 
> **Overview**
> Fixes the IAM trust policy for the `control-plane` role by changing the assume-role condition key from `aws:ExternalId` to the correct `sts:ExternalId`, ensuring the external ID check is actually enforced during `sts:AssumeRole`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d10a73084869bf08d63500435d86875eba965b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->