### PR TITLE
fix: trust realm controller for cloudd connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ module "connection" {
 
 | Name                                                                                   | Description              | Value        | Sensitive |
 | -------------------------------------------------------------------------------------- | ------------------------ | ------------ | :-------: |
-| <a name="output_cloudd-role-arn"></a> [cloudd-role-arn](#output_cloudd-role-arn)       | ARN of the cloudd connection role | `"ROLE-ARN"` |    no     |
+| <a name="output_connection-controller-role-arn"></a> [connection-controller-role-arn](#output_connection-controller-role-arn) | ARN of the connection controller role | `"ROLE-ARN"` |    no     |
 | <a name="output_instance-role-arn"></a> [instance-role-arn](#output_instance-role-arn) | ARN of the instance role | `"ROLE-ARN"` |    no     |
 | <a name="output_instance-role-id"></a> [instance-role-id](#output_instance-role-id)    | ID of the instance role  | `"ROLE-ID"`  |    no     |
 | <a name="output_route-table-id"></a> [route-table-id](#output_route-table-id)          | VPC route table ID       | `"null"`     |    no     |

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ module "connection" {
   source        = "depot/connection/aws"
   version       = "x.x.x"
   connection-id = "xxxxxx"
+  controller-role-arn = "arn:aws:iam::123456789012:role/depot-controller-example"
   cidr-block    = "10.0.0.0/16"
   subnets = [
     { availability-zone = "us-east-1a", cidr-block = "10.0.1.0/18" },
@@ -21,6 +22,7 @@ module "connection" {
 | Name                                                                              | Description                                                    | Type                                                                | Default         | Required |
 | --------------------------------------------------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------- | --------------- | :------: |
 | <a name="input_connection-id"></a> [connection-id](#input_connection-id)          | ID for the Depot connection (provided in the Depot console)    | `string`                                                            | n/a             |   yes    |
+| <a name="input_controller-role-arn"></a> [controller-role-arn](#input_controller-role-arn) | ARN of the Depot realm controller role that can assume this connection role | `string`                                                            | n/a             |   yes    |
 | <a name="input_subnets"></a> [subnets](#input_subnets)                            | Subnets to use for the VPC                                     | `list(object({ availability-zone = string, cidr-block = string }))` | n/a             |   yes    |
 | <a name="input_allow-ssm-access"></a> [allow-ssm-access](#input_allow-ssm-access) | Controls if SSM access should be allowed for the EC2 instances | `bool`                                                              | `false`         |    no    |
 | <a name="input_cidr-block"></a> [cidr-block](#input_cidr-block)                   | VPC CIDR block                                                 | `string`                                                            | `"10.0.0.0/16"` |    no    |
@@ -30,6 +32,7 @@ module "connection" {
 
 | Name                                                                                   | Description              | Value        | Sensitive |
 | -------------------------------------------------------------------------------------- | ------------------------ | ------------ | :-------: |
+| <a name="output_cloudd-role-arn"></a> [cloudd-role-arn](#output_cloudd-role-arn)       | ARN of the cloudd connection role | `"ROLE-ARN"` |    no     |
 | <a name="output_instance-role-arn"></a> [instance-role-arn](#output_instance-role-arn) | ARN of the instance role | `"ROLE-ARN"` |    no     |
 | <a name="output_instance-role-id"></a> [instance-role-id](#output_instance-role-id)    | ID of the instance role  | `"ROLE-ID"`  |    no     |
 | <a name="output_route-table-id"></a> [route-table-id](#output_route-table-id)          | VPC route table ID       | `"null"`     |    no     |

--- a/main.tf
+++ b/main.tf
@@ -136,8 +136,8 @@ resource "aws_ssm_parameter" "connection" {
   tags = merge(var.tags, { "depot-connection" = var.connection-id })
 }
 
-resource "aws_iam_policy" "cloudd" {
-  name = "depot-connection-${var.connection-id}-cloudd"
+resource "aws_iam_policy" "controller" {
+  name = "depot-connection-${var.connection-id}-controller"
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -223,8 +223,8 @@ resource "aws_iam_policy" "cloudd" {
   })
 }
 
-resource "aws_iam_role" "cloudd" {
-  name = "depot-connection-${var.connection-id}-cloudd"
+resource "aws_iam_role" "controller" {
+  name = "depot-connection-${var.connection-id}-controller"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
@@ -235,7 +235,7 @@ resource "aws_iam_role" "cloudd" {
   })
 }
 
-resource "aws_iam_role_policy_attachments_exclusive" "cloudd" {
-  role_name   = aws_iam_role.cloudd.name
-  policy_arns = [aws_iam_policy.cloudd.arn]
+resource "aws_iam_role_policy_attachments_exclusive" "controller" {
+  role_name   = aws_iam_role.controller.name
+  policy_arns = [aws_iam_policy.controller.arn]
 }

--- a/main.tf
+++ b/main.tf
@@ -136,8 +136,8 @@ resource "aws_ssm_parameter" "connection" {
   tags = merge(var.tags, { "depot-connection" = var.connection-id })
 }
 
-resource "aws_iam_policy" "control-plane" {
-  name = "depot-connection-${var.connection-id}-control-plane"
+resource "aws_iam_policy" "cloudd" {
+  name = "depot-connection-${var.connection-id}-cloudd"
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -223,24 +223,19 @@ resource "aws_iam_policy" "control-plane" {
   })
 }
 
-resource "aws_iam_role" "control-plane" {
-  name = "depot-connection-${var.connection-id}-control-plane"
+resource "aws_iam_role" "cloudd" {
+  name = "depot-connection-${var.connection-id}-cloudd"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
       Action    = "sts:AssumeRole"
       Effect    = "Allow"
-      Principal = { AWS = "375021575472" }
-      Condition = {
-        StringEquals = {
-          "sts:ExternalId" = var.connection-id
-        }
-      }
+      Principal = { AWS = var.controller-role-arn }
     }]
   })
 }
 
-resource "aws_iam_role_policy_attachments_exclusive" "control-plane" {
-  role_name   = aws_iam_role.control-plane.name
-  policy_arns = [aws_iam_policy.control-plane.arn]
+resource "aws_iam_role_policy_attachments_exclusive" "cloudd" {
+  role_name   = aws_iam_role.cloudd.name
+  policy_arns = [aws_iam_policy.cloudd.arn]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,9 +8,9 @@ output "instance-role-id" {
   description = "ID of the instance role"
 }
 
-output "cloudd-role-arn" {
-  value       = try(aws_iam_role.cloudd.arn, "")
-  description = "ARN of the cloudd connection role"
+output "connection-controller-role-arn" {
+  value       = try(aws_iam_role.controller.arn, "")
+  description = "ARN of the connection controller role"
 }
 
 output "vpc-id" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,11 @@ output "instance-role-id" {
   description = "ID of the instance role"
 }
 
+output "cloudd-role-arn" {
+  value       = try(aws_iam_role.cloudd.arn, "")
+  description = "ARN of the cloudd connection role"
+}
+
 output "vpc-id" {
   value       = try(aws_vpc.vpc.id, "")
   description = "VPC ID"

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,11 @@ variable "subnets" {
   description = "Subnets to use for the VPC"
 }
 
+variable "controller-role-arn" {
+  type        = string
+  description = "ARN of the Depot realm controller role that can assume this connection role"
+}
+
 // Optional
 
 variable "tags" {


### PR DESCRIPTION
## Summary

Realm-backed connections now expose the IAM role shape the realm controller should assume. Instead of trusting the Depot account root with an external ID on a `control-plane` role, the module now creates `depot-connection-<id>-controller` and trusts the caller-provided realm controller role ARN.

This lets each realm controller assume per-connection roles while keeping the connection permissions scoped by `connection-id` tags and metadata.

## Testing

- `terraform fmt -check`
- `git diff --check`
- `terraform validate` could not complete locally because the installed AWS provider plugin fails to instantiate with `Unrecognized remote plugin message`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
