### PR TITLE
fix: allow controller to resize resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -178,7 +178,7 @@ resource "aws_iam_policy" "controller" {
       },
 
       {
-        Action    = ["ec2:DeleteVolume", "ec2:StartInstances", "ec2:StopInstances", "ec2:TerminateInstances"]
+        Action    = ["ec2:DeleteVolume", "ec2:ModifyInstanceAttribute", "ec2:ModifyVolume", "ec2:StartInstances", "ec2:StopInstances", "ec2:TerminateInstances"]
         Effect    = "Allow"
         Resource  = "*"
         Condition = { StringEquals = { "aws:ResourceTag/depot-connection" = var.connection-id } }


### PR DESCRIPTION
## Summary

Allow the per-connection controller role to resize resources tagged with the connection ID:

- ec2:ModifyInstanceAttribute for stopped builder instance type changes
- ec2:ModifyVolume for root/cache volume size, IOPS, or throughput changes

The aws-managed-builder module uses these calls while reconciling existing managed builder resources.

## Testing

- terraform fmt -check main.tf
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands destructive-capable EC2 permissions on the cross-account controller role, though still limited by the depot-connection resource tag condition.
> 
> **Overview**
> Extends the per-connection **controller** IAM policy so it can resize EC2 resources that carry the `depot-connection` resource tag.
> 
> The tagged-resource statement now allows **`ec2:ModifyInstanceAttribute`** and **`ec2:ModifyVolume`** alongside the existing stop/start/terminate/delete volume actions, so the managed builder controller can change instance type and volume size/IOPS/throughput during reconciliation without broader account permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faa1ab06f8b4d988ede4056ca42c4d1976a5f60b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->