### PR TITLE
fix: support govcloud connection configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 # Crash log files
 crash.log
 
+.idea
+
 # Exclude all .tfvars files, which are likely to contain sentitive data, such as
 # password, private keys, and other secrets. These should not be part of version
 # control as they are data points which are potentially sensitive and subject

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ```tf
 module "connection" {
-  source        = "depot/connection/aws"
-  version       = "x.x.x"
-  connection-id = "xxxxxx"
-  controller-role-arn = "arn:aws:iam::123456789012:role/depot-controller-example"
-  cidr-block    = "10.0.0.0/16"
+  source              = "depot/connection/aws"
+  version             = "x.x.x"
+  connection-id       = "xxxxxx"
+  controller-role-arn = "arn:${data.aws_partition.current.partition}:iam::123456789012:role/depot-controller-example"
+  cidr-block          = "10.0.0.0/16"
   subnets = [
     { availability-zone = "us-east-1a", cidr-block = "10.0.1.0/18" },
     { availability-zone = "us-east-1b", cidr-block = "10.0.64.0/18" },
@@ -15,27 +15,71 @@ module "connection" {
 }
 ```
 
+## Private/customer-managed networking
+
+```tf
+module "connection" {
+  source = "depot/connection/aws"
+
+  connection-id       = "xxxxxx"
+  controller-role-arn = module.controller.controller-role-arn
+
+  vpc-id = "vpc-123"
+  existing-subnets = [
+    { id = "subnet-123", availability-zone = "us-gov-west-1a", cidr-block = "10.10.1.0/24" },
+    { id = "subnet-456", availability-zone = "us-gov-west-1b", cidr-block = "10.10.2.0/24" },
+  ]
+  security-groups = {
+    buildkit = "sg-123"
+    default  = "sg-456"
+  }
+
+  associate-public-ip-address = false
+  flow-log-destination-arn    = "arn:aws-us-gov:logs:us-gov-west-1:123456789012:log-group:/aws/vpc/flowlogs"
+
+  connection-parameter-type       = "SecureString"
+  connection-parameter-kms-key-id = "arn:aws-us-gov:kms:us-gov-west-1:123456789012:key/..."
+  root-volume-kms-key-id          = "arn:aws-us-gov:kms:us-gov-west-1:123456789012:key/..."
+  cache-volume-kms-key-id         = "arn:aws-us-gov:kms:us-gov-west-1:123456789012:key/..."
+  launch-template-id              = "lt-123"
+}
+```
+
 <!-- BEGIN_TF_DOCS -->
 
 ## Inputs
 
-| Name                                                                              | Description                                                    | Type                                                                | Default         | Required |
-| --------------------------------------------------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------- | --------------- | :------: |
-| <a name="input_connection-id"></a> [connection-id](#input_connection-id)          | ID for the Depot connection (provided in the Depot console)    | `string`                                                            | n/a             |   yes    |
+| Name                                                                              | Description                                                                  | Type                                                                | Default         | Required |
+| --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------- | --------------- | :------: |
+| <a name="input_connection-id"></a> [connection-id](#input_connection-id)          | ID for the Depot connection (provided in the Depot console)                  | `string`                                                            | n/a             |   yes    |
 | <a name="input_controller-role-arn"></a> [controller-role-arn](#input_controller-role-arn) | ARN of the Depot realm controller role that can assume this connection role | `string`                                                            | n/a             |   yes    |
-| <a name="input_subnets"></a> [subnets](#input_subnets)                            | Subnets to use for the VPC                                     | `list(object({ availability-zone = string, cidr-block = string }))` | n/a             |   yes    |
-| <a name="input_allow-ssm-access"></a> [allow-ssm-access](#input_allow-ssm-access) | Controls if SSM access should be allowed for the EC2 instances | `bool`                                                              | `false`         |    no    |
-| <a name="input_cidr-block"></a> [cidr-block](#input_cidr-block)                   | VPC CIDR block                                                 | `string`                                                            | `"10.0.0.0/16"` |    no    |
-| <a name="input_tags"></a> [tags](#input_tags)                                     | A map of tags to apply to all resources                        | `map(string)`                                                       | `{}`            |    no    |
+| <a name="input_allow-ssm-access"></a> [allow-ssm-access](#input_allow-ssm-access) | Controls if SSM access should be allowed for the EC2 instances               | `bool`                                                              | `false`         |    no    |
+| <a name="input_associate-public-ip-address"></a> [associate-public-ip-address](#input_associate-public-ip-address) | Whether Depot should associate public IPs when launching instances | `bool` | `true` | no |
+| <a name="input_cache-volume-kms-key-id"></a> [cache-volume-kms-key-id](#input_cache-volume-kms-key-id) | KMS key ID or ARN Depot should use for cache/data volumes | `string` | `null` | no |
+| <a name="input_cidr-block"></a> [cidr-block](#input_cidr-block)                   | VPC CIDR block                                                               | `string`                                                            | `"10.0.0.0/16"` |    no    |
+| <a name="input_connection-parameter-kms-key-id"></a> [connection-parameter-kms-key-id](#input_connection-parameter-kms-key-id) | KMS key ID or ARN for the SSM SecureString connection metadata parameter | `string` | `null` | no |
+| <a name="input_connection-parameter-type"></a> [connection-parameter-type](#input_connection-parameter-type) | SSM parameter type for connection metadata | `string` | `"String"` | no |
+| <a name="input_create-internet-gateway"></a> [create-internet-gateway](#input_create-internet-gateway) | Whether to create public internet routing for module-managed subnets | `bool` | `true` | no |
+| <a name="input_existing-subnets"></a> [existing-subnets](#input_existing-subnets) | Existing subnets to use instead of creating subnets | `list(object({ id = string, availability-zone = string, cidr-block = string }))` | `[]` | no |
+| <a name="input_flow-log-destination-arn"></a> [flow-log-destination-arn](#input_flow-log-destination-arn) | Destination ARN for VPC flow logs | `string` | `null` | no |
+| <a name="input_launch-template-id"></a> [launch-template-id](#input_launch-template-id) | Launch template ID Depot should use when launching instances | `string` | `null` | no |
+| <a name="input_root-volume-kms-key-id"></a> [root-volume-kms-key-id](#input_root-volume-kms-key-id) | KMS key ID or ARN Depot should use for launched instance root volumes | `string` | `null` | no |
+| <a name="input_security-groups"></a> [security-groups](#input_security-groups) | Existing security groups for Depot instances | `object({ buildkit = string, default = string })` | `null` | no |
+| <a name="input_subnets"></a> [subnets](#input_subnets)                            | Subnets to create in the module-managed VPC                                  | `list(object({ availability-zone = string, cidr-block = string }))` | `[]`            |    no    |
+| <a name="input_tags"></a> [tags](#input_tags)                                     | A map of tags to apply to all resources                                      | `map(string)`                                                       | `{}`            |    no    |
+| <a name="input_vpc-id"></a> [vpc-id](#input_vpc-id)                               | Existing VPC ID to use instead of creating a VPC                             | `string`                                                            | `null`          |    no    |
 
 ## Outputs
 
-| Name                                                                                   | Description              | Value        | Sensitive |
-| -------------------------------------------------------------------------------------- | ------------------------ | ------------ | :-------: |
+| Name                                                                                   | Description                            | Value        | Sensitive |
+| -------------------------------------------------------------------------------------- | -------------------------------------- | ------------ | :-------: |
+| <a name="output_connection-metadata"></a> [connection-metadata](#output_connection-metadata) | Connection metadata written for Depot | `"METADATA"` | yes |
 | <a name="output_connection-controller-role-arn"></a> [connection-controller-role-arn](#output_connection-controller-role-arn) | ARN of the connection controller role | `"ROLE-ARN"` |    no     |
 | <a name="output_instance-role-arn"></a> [instance-role-arn](#output_instance-role-arn) | ARN of the instance role | `"ROLE-ARN"` |    no     |
 | <a name="output_instance-role-id"></a> [instance-role-id](#output_instance-role-id)    | ID of the instance role  | `"ROLE-ID"`  |    no     |
 | <a name="output_route-table-id"></a> [route-table-id](#output_route-table-id)          | VPC route table ID       | `"null"`     |    no     |
+| <a name="output_security-groups"></a> [security-groups](#output_security-groups)       | Security groups used by Depot instances | `"SECURITY-GROUPS"` | no |
+| <a name="output_subnets"></a> [subnets](#output_subnets)                               | Subnets used by Depot instances | `"SUBNETS"` | no |
 | <a name="output_vpc-id"></a> [vpc-id](#output_vpc-id)                                  | VPC ID                   | `"VPC-ID"`   |    no     |
 
 <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -37,13 +37,12 @@ module "connection" {
   associate-public-ip-address = false
 
   connection-parameter-kms-key-id = "arn:aws-us-gov:kms:us-gov-west-1:123456789012:key/..."
-  root-volume-kms-key-id          = "arn:aws-us-gov:kms:us-gov-west-1:123456789012:key/..."
-  cache-volume-kms-key-id         = "arn:aws-us-gov:kms:us-gov-west-1:123456789012:key/..."
+  volume-kms-key-id               = "arn:aws-us-gov:kms:us-gov-west-1:123456789012:key/..."
   launch-template-id              = "lt-123"
 }
 ```
 
-The connection metadata includes `kmsKeyID` and `launchTemplateID` when `cache-volume-kms-key-id` and `launch-template-id` are provided, so Depot can use those values when launching instances and creating volumes.
+The connection metadata includes `volumeKMSKeyID` and `launchTemplateID` when `volume-kms-key-id` and `launch-template-id` are provided, so Depot can use those values when launching instances and creating EBS volumes.
 
 <!-- BEGIN_TF_DOCS -->
 
@@ -55,16 +54,15 @@ The connection metadata includes `kmsKeyID` and `launchTemplateID` when `cache-v
 | <a name="input_controller-role-arn"></a> [controller-role-arn](#input_controller-role-arn) | ARN of the Depot realm controller role that can assume this connection role | `string`                                                            | n/a             |   yes    |
 | <a name="input_allow-ssm-access"></a> [allow-ssm-access](#input_allow-ssm-access) | Controls if SSM access should be allowed for the EC2 instances               | `bool`                                                              | `false`         |    no    |
 | <a name="input_associate-public-ip-address"></a> [associate-public-ip-address](#input_associate-public-ip-address) | Whether Depot should associate public IPs when launching instances | `bool` | `true` | no |
-| <a name="input_cache-volume-kms-key-id"></a> [cache-volume-kms-key-id](#input_cache-volume-kms-key-id) | KMS key ID or ARN Depot should use for cache/data volumes | `string` | `null` | no |
 | <a name="input_cidr-block"></a> [cidr-block](#input_cidr-block)                   | VPC CIDR block                                                               | `string`                                                            | `"10.0.0.0/16"` |    no    |
 | <a name="input_connection-parameter-kms-key-id"></a> [connection-parameter-kms-key-id](#input_connection-parameter-kms-key-id) | KMS key ID or ARN for the SSM SecureString connection metadata parameter | `string` | `null` | no |
 | <a name="input_create-internet-gateway"></a> [create-internet-gateway](#input_create-internet-gateway) | Whether to create public internet routing for module-managed subnets | `bool` | `true` | no |
 | <a name="input_existing-subnets"></a> [existing-subnets](#input_existing-subnets) | Existing subnets to use instead of creating subnets | `list(object({ id = string, availability-zone = string, cidr-block = string }))` | `[]` | no |
 | <a name="input_launch-template-id"></a> [launch-template-id](#input_launch-template-id) | Launch template ID Depot should use when launching instances | `string` | `null` | no |
-| <a name="input_root-volume-kms-key-id"></a> [root-volume-kms-key-id](#input_root-volume-kms-key-id) | KMS key ID or ARN Depot should use for launched instance root volumes | `string` | `null` | no |
 | <a name="input_security-groups"></a> [security-groups](#input_security-groups) | Existing security groups for Depot instances | `object({ buildkit = string, default = string })` | `null` | no |
 | <a name="input_subnets"></a> [subnets](#input_subnets)                            | Subnets to create in the module-managed VPC                                  | `list(object({ availability-zone = string, cidr-block = string }))` | `[]`            |    no    |
 | <a name="input_tags"></a> [tags](#input_tags)                                     | A map of tags to apply to all resources                                      | `map(string)`                                                       | `{}`            |    no    |
+| <a name="input_volume-kms-key-id"></a> [volume-kms-key-id](#input_volume-kms-key-id) | KMS key ID or ARN Depot should use for launched instance root and cache/data EBS volumes | `string` | `null` | no |
 | <a name="input_vpc-id"></a> [vpc-id](#input_vpc-id)                               | Existing VPC ID to use instead of creating a VPC                             | `string`                                                            | `null`          |    no    |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ module "connection" {
   associate-public-ip-address = false
   flow-log-destination-arn    = "arn:aws-us-gov:logs:us-gov-west-1:123456789012:log-group:/aws/vpc/flowlogs"
 
-  connection-parameter-type       = "SecureString"
   connection-parameter-kms-key-id = "arn:aws-us-gov:kms:us-gov-west-1:123456789012:key/..."
   root-volume-kms-key-id          = "arn:aws-us-gov:kms:us-gov-west-1:123456789012:key/..."
   cache-volume-kms-key-id         = "arn:aws-us-gov:kms:us-gov-west-1:123456789012:key/..."
@@ -58,7 +57,6 @@ module "connection" {
 | <a name="input_cache-volume-kms-key-id"></a> [cache-volume-kms-key-id](#input_cache-volume-kms-key-id) | KMS key ID or ARN Depot should use for cache/data volumes | `string` | `null` | no |
 | <a name="input_cidr-block"></a> [cidr-block](#input_cidr-block)                   | VPC CIDR block                                                               | `string`                                                            | `"10.0.0.0/16"` |    no    |
 | <a name="input_connection-parameter-kms-key-id"></a> [connection-parameter-kms-key-id](#input_connection-parameter-kms-key-id) | KMS key ID or ARN for the SSM SecureString connection metadata parameter | `string` | `null` | no |
-| <a name="input_connection-parameter-type"></a> [connection-parameter-type](#input_connection-parameter-type) | SSM parameter type for connection metadata | `string` | `"String"` | no |
 | <a name="input_create-internet-gateway"></a> [create-internet-gateway](#input_create-internet-gateway) | Whether to create public internet routing for module-managed subnets | `bool` | `true` | no |
 | <a name="input_existing-subnets"></a> [existing-subnets](#input_existing-subnets) | Existing subnets to use instead of creating subnets | `list(object({ id = string, availability-zone = string, cidr-block = string }))` | `[]` | no |
 | <a name="input_flow-log-destination-arn"></a> [flow-log-destination-arn](#input_flow-log-destination-arn) | Destination ARN for VPC flow logs | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ module "connection" {
   }
 
   associate-public-ip-address = false
-  flow-log-destination-arn    = "arn:aws-us-gov:logs:us-gov-west-1:123456789012:log-group:/aws/vpc/flowlogs"
 
   connection-parameter-kms-key-id = "arn:aws-us-gov:kms:us-gov-west-1:123456789012:key/..."
   root-volume-kms-key-id          = "arn:aws-us-gov:kms:us-gov-west-1:123456789012:key/..."
@@ -43,6 +42,8 @@ module "connection" {
   launch-template-id              = "lt-123"
 }
 ```
+
+The connection metadata includes `kmsKeyID` and `launchTemplateID` when `cache-volume-kms-key-id` and `launch-template-id` are provided, so Depot can use those values when launching instances and creating volumes.
 
 <!-- BEGIN_TF_DOCS -->
 
@@ -59,7 +60,6 @@ module "connection" {
 | <a name="input_connection-parameter-kms-key-id"></a> [connection-parameter-kms-key-id](#input_connection-parameter-kms-key-id) | KMS key ID or ARN for the SSM SecureString connection metadata parameter | `string` | `null` | no |
 | <a name="input_create-internet-gateway"></a> [create-internet-gateway](#input_create-internet-gateway) | Whether to create public internet routing for module-managed subnets | `bool` | `true` | no |
 | <a name="input_existing-subnets"></a> [existing-subnets](#input_existing-subnets) | Existing subnets to use instead of creating subnets | `list(object({ id = string, availability-zone = string, cidr-block = string }))` | `[]` | no |
-| <a name="input_flow-log-destination-arn"></a> [flow-log-destination-arn](#input_flow-log-destination-arn) | Destination ARN for VPC flow logs | `string` | `null` | no |
 | <a name="input_launch-template-id"></a> [launch-template-id](#input_launch-template-id) | Launch template ID Depot should use when launching instances | `string` | `null` | no |
 | <a name="input_root-volume-kms-key-id"></a> [root-volume-kms-key-id](#input_root-volume-kms-key-id) | KMS key ID or ARN Depot should use for launched instance root volumes | `string` | `null` | no |
 | <a name="input_security-groups"></a> [security-groups](#input_security-groups) | Existing security groups for Depot instances | `object({ buildkit = string, default = string })` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,44 +1,110 @@
 # Data providers
 
 data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
 data "aws_region" "current" {}
+
+locals {
+  create_vpc             = var.vpc-id == null
+  create_subnets         = length(var.existing-subnets) == 0
+  create_security_groups = var.security-groups == null
+  create_public_route    = local.create_vpc && local.create_subnets && var.create-internet-gateway
+
+  partition  = data.aws_partition.current.partition
+  account_id = data.aws_caller_identity.current.account_id
+  region     = data.aws_region.current.region
+
+  vpc_id         = local.create_vpc ? aws_vpc.vpc[0].id : var.vpc-id
+  route_table_id = local.create_public_route ? aws_route_table.public[0].id : var.route-table-id
+
+  subnets = local.create_subnets ? [
+    for subnet in aws_subnet.public : {
+      id               = subnet.id
+      availabilityZone = subnet.availability_zone
+      cidrBlock        = subnet.cidr_block
+      arn              = subnet.arn
+    }
+    ] : [
+    for subnet in var.existing-subnets : {
+      id               = subnet.id
+      availabilityZone = subnet.availability-zone
+      cidrBlock        = subnet.cidr-block
+      arn              = "arn:${local.partition}:ec2:${local.region}:${local.account_id}:subnet/${subnet.id}"
+    }
+  ]
+
+  security_groups = local.create_security_groups ? {
+    buildkit = aws_security_group.instance-buildkit[0].id
+    default  = aws_security_group.instance-default[0].id
+  } : var.security-groups
+
+  security_group_arns = local.create_security_groups ? [
+    aws_security_group.instance-buildkit[0].arn,
+    aws_security_group.instance-default[0].arn,
+    ] : [
+    "arn:${local.partition}:ec2:${local.region}:${local.account_id}:security-group/${var.security-groups.buildkit}",
+    "arn:${local.partition}:ec2:${local.region}:${local.account_id}:security-group/${var.security-groups.default}",
+  ]
+
+  kms_key_arns = [
+    for arn in [
+      var.root-volume-kms-key-id,
+      var.cache-volume-kms-key-id,
+      var.connection-parameter-kms-key-id,
+    ] : arn if arn != null && arn != ""
+  ]
+}
 
 # VPC
 
 resource "aws_vpc" "vpc" {
+  count      = local.create_vpc ? 1 : 0
   cidr_block = var.cidr-block
   tags       = merge(var.tags, { Name = "depot-connection-${var.connection-id}" })
 }
 
 resource "aws_internet_gateway" "internet-gateway" {
-  vpc_id = aws_vpc.vpc.id
+  count  = local.create_public_route ? 1 : 0
+  vpc_id = local.vpc_id
   tags   = merge(var.tags, { Name = "depot-connection-${var.connection-id}" })
 }
 
 resource "aws_route_table" "public" {
-  vpc_id = aws_vpc.vpc.id
+  count  = local.create_public_route ? 1 : 0
+  vpc_id = local.vpc_id
   tags   = merge(var.tags, { Name = "depot-connection-${var.connection-id}" })
 }
 
 resource "aws_route" "public-internet-gateway" {
-  route_table_id         = aws_route_table.public.id
+  count                  = local.create_public_route ? 1 : 0
+  route_table_id         = aws_route_table.public[0].id
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = aws_internet_gateway.internet-gateway.id
+  gateway_id             = aws_internet_gateway.internet-gateway[0].id
 }
 
 resource "aws_subnet" "public" {
-  count                   = length(var.subnets)
-  vpc_id                  = aws_vpc.vpc.id
+  count                   = local.create_subnets ? length(var.subnets) : 0
+  vpc_id                  = local.vpc_id
   availability_zone       = var.subnets[count.index].availability-zone
   cidr_block              = var.subnets[count.index].cidr-block
-  map_public_ip_on_launch = true
+  map_public_ip_on_launch = var.map-public-ip-on-launch
   tags                    = merge(var.tags, { "Name" = "depot-${var.connection-id}-${var.subnets[count.index].availability-zone}" })
 }
 
 resource "aws_route_table_association" "public" {
-  count          = length(var.subnets)
+  count          = local.create_public_route ? length(aws_subnet.public) : 0
   subnet_id      = aws_subnet.public[count.index].id
-  route_table_id = aws_route_table.public.id
+  route_table_id = aws_route_table.public[0].id
+}
+
+resource "aws_flow_log" "vpc" {
+  count                = var.flow-log-destination-arn == null ? 0 : 1
+  vpc_id               = local.vpc_id
+  traffic_type         = var.flow-log-traffic-type
+  log_destination      = var.flow-log-destination-arn
+  log_destination_type = var.flow-log-destination-type
+  iam_role_arn         = var.flow-log-iam-role-arn
+  tags                 = merge(var.tags, { Name = "depot-connection-${var.connection-id}" })
 }
 
 # Instance IAM
@@ -63,74 +129,81 @@ resource "aws_iam_instance_profile" "instance" {
 resource "aws_iam_role_policy_attachment" "instance-ssm" {
   count      = var.allow-ssm-access ? 1 : 0
   role       = aws_iam_role.instance.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  policy_arn = "arn:${local.partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
 # Security Groups
 
 resource "aws_default_security_group" "default" {
-  vpc_id = aws_vpc.vpc.id
+  count  = local.create_vpc ? 1 : 0
+  vpc_id = local.vpc_id
 }
 
 resource "aws_security_group" "instance-buildkit" {
+  count       = local.create_security_groups ? 1 : 0
   name        = "depot-connection-${var.connection-id}-instance-buildkit"
   description = "Security group for Depot connection BuildKit instances"
-  vpc_id      = aws_vpc.vpc.id
+  vpc_id      = local.vpc_id
 
   ingress {
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = var.buildkit-ingress-cidr-blocks
   }
 
   egress {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = var.buildkit-egress-cidr-blocks
   }
 
   tags = merge(var.tags, { Name = "depot-connection-${var.connection-id}-instance-buildkit" })
 }
 
 resource "aws_security_group" "instance-default" {
+  count       = local.create_security_groups ? 1 : 0
   name        = "depot-connection-${var.connection-id}-instance-default"
   description = "Security group for Depot connection instances"
-  vpc_id      = aws_vpc.vpc.id
+  vpc_id      = local.vpc_id
 
   egress {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = var.default-egress-cidr-blocks
   }
 
   tags = merge(var.tags, { Name = "depot-connection-${var.connection-id}-instance-default" })
 }
 
 resource "aws_ssm_parameter" "connection" {
-  name = "/depot/connection/${var.connection-id}"
-  type = "String"
+  name   = "/depot/connection/${var.connection-id}"
+  type   = var.connection-parameter-type
+  key_id = var.connection-parameter-kms-key-id
   value = jsonencode({
-    accountID          = data.aws_caller_identity.current.account_id
-    connectionID       = var.connection-id
-    instanceProfileARN = aws_iam_instance_profile.instance.arn
-    instanceRoleARN    = aws_iam_role.instance.arn
-    region             = data.aws_region.current.region
-    routeTableID       = aws_route_table.public.id
-    securityGroups = {
-      buildkit = aws_security_group.instance-buildkit.id
-      default  = aws_security_group.instance-default.id
-    }
+    accountID                = local.account_id
+    associatePublicIPAddress = var.associate-public-ip-address
+    cacheVolumeKMSKeyID      = var.cache-volume-kms-key-id
+    connectionID             = var.connection-id
+    controllerRoleARN        = aws_iam_role.controller.arn
+    instanceProfileARN       = aws_iam_instance_profile.instance.arn
+    instanceRoleARN          = aws_iam_role.instance.arn
+    launchTemplateID         = var.launch-template-id
+    partition                = local.partition
+    region                   = local.region
+    rootVolumeKMSKeyID       = var.root-volume-kms-key-id
+    routeTableID             = local.route_table_id
+    securityGroups           = local.security_groups
     subnets = [
-      for subnet in aws_subnet.public : {
+      for subnet in local.subnets : {
         id               = subnet.id
-        availabilityZone = subnet.availability_zone
-        cidrBlock        = subnet.cidr_block
+        availabilityZone = subnet.availabilityZone
+        cidrBlock        = subnet.cidrBlock
       }
     ]
-    vpcID = aws_vpc.vpc.id
+    vpcID = local.vpc_id
   })
 
   tags = merge(var.tags, { "depot-connection" = var.connection-id })
@@ -140,9 +213,9 @@ resource "aws_iam_policy" "controller" {
   name = "depot-connection-${var.connection-id}-controller"
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [
+    Statement = concat([
       {
-        Action   = ["ec2:DescribeInstances", "ec2:DescribeVolumes"]
+        Action   = ["ec2:DescribeInstances", "ec2:DescribeVolumes", "ec2:DescribeLaunchTemplates", "ec2:DescribeLaunchTemplateVersions"]
         Effect   = "Allow"
         Resource = "*"
       },
@@ -157,19 +230,22 @@ resource "aws_iam_policy" "controller" {
       {
         Action = ["ec2:RunInstances"]
         Effect = "Allow"
-        Resource = concat([
-          aws_security_group.instance-buildkit.arn,
-          aws_security_group.instance-default.arn,
-          "arn:aws:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:network-interface/*",
-          "arn:aws:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:volume/*",
-          "arn:aws:ec2:${data.aws_region.current.region}::image/*",
-        ], [for s in aws_subnet.public : s.arn])
+        Resource = concat(
+          local.security_group_arns,
+          [
+            "arn:${local.partition}:ec2:${local.region}:${local.account_id}:network-interface/*",
+            "arn:${local.partition}:ec2:${local.region}:${local.account_id}:volume/*",
+            "arn:${local.partition}:ec2:${local.region}::image/*",
+          ],
+          [for subnet in local.subnets : subnet.arn],
+          var.launch-template-id == null ? [] : ["arn:${local.partition}:ec2:${local.region}:${local.account_id}:launch-template/${var.launch-template-id}"],
+        )
       },
 
       {
         Action   = ["ec2:RunInstances"]
         Effect   = "Allow"
-        Resource = "arn:aws:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:instance/*",
+        Resource = "arn:${local.partition}:ec2:${local.region}:${local.account_id}:instance/*",
         Condition = {
           StringEquals = {
             "aws:RequestTag/depot-connection" = var.connection-id,
@@ -187,14 +263,14 @@ resource "aws_iam_policy" "controller" {
       {
         Action    = ["ec2:AttachVolume", "ec2:DetachVolume"],
         Effect    = "Allow",
-        Resource  = ["arn:aws:ec2:*:*:instance/*", "arn:aws:ec2:*:*:volume/*"],
+        Resource  = ["arn:${local.partition}:ec2:*:*:instance/*", "arn:${local.partition}:ec2:*:*:volume/*"],
         Condition = { StringEquals = { "aws:ResourceTag/depot-connection" = var.connection-id } }
       },
 
       {
         Action   = ["ec2:CreateTags"],
         Effect   = "Allow",
-        Resource = "arn:aws:ec2:*:*:*/*",
+        Resource = "arn:${local.partition}:ec2:*:*:*/*",
         Condition = {
           StringEquals = {
             "aws:RequestTag/depot-connection" = var.connection-id,
@@ -219,7 +295,15 @@ resource "aws_iam_policy" "controller" {
         Effect   = "Allow"
         Resource = aws_ssm_parameter.connection.arn
       },
-    ]
+      ],
+      length(local.kms_key_arns) == 0 ? [] : [
+        {
+          Action   = ["kms:CreateGrant", "kms:DescribeKey", "kms:Encrypt", "kms:Decrypt", "kms:GenerateDataKeyWithoutPlaintext", "kms:ReEncryptFrom", "kms:ReEncryptTo"]
+          Effect   = "Allow"
+          Resource = local.kms_key_arns
+        }
+      ]
+    )
   })
 }
 

--- a/main.tf
+++ b/main.tf
@@ -46,13 +46,14 @@ locals {
     "arn:${local.partition}:ec2:${local.region}:${local.account_id}:security-group/${var.security-groups.default}",
   ]
 
-  kms_key_arns = [
-    for arn in [
-      var.root-volume-kms-key-id,
-      var.cache-volume-kms-key-id,
-      var.connection-parameter-kms-key-id,
-    ] : arn if arn != null && arn != ""
-  ]
+  kms_key_ids = compact([
+    var.volume-kms-key-id,
+    var.connection-parameter-kms-key-id,
+  ])
+
+  kms_key_arns = distinct([
+    for key_id in local.kms_key_ids : startswith(key_id, "arn:") ? key_id : "arn:${local.partition}:kms:${local.region}:${local.account_id}:key/${key_id}"
+  ])
 }
 
 # VPC
@@ -175,16 +176,13 @@ resource "aws_ssm_parameter" "connection" {
   value = jsonencode({
     accountID                = local.account_id
     associatePublicIPAddress = var.associate-public-ip-address
-    cacheVolumeKMSKeyID      = var.cache-volume-kms-key-id
     connectionID             = var.connection-id
     controllerRoleARN        = aws_iam_role.controller.arn
     instanceProfileARN       = aws_iam_instance_profile.instance.arn
     instanceRoleARN          = aws_iam_role.instance.arn
-    kmsKeyID                 = var.cache-volume-kms-key-id
     launchTemplateID         = var.launch-template-id
     partition                = local.partition
     region                   = local.region
-    rootVolumeKMSKeyID       = var.root-volume-kms-key-id
     routeTableID             = local.route_table_id
     securityGroups           = local.security_groups
     subnets = [
@@ -194,7 +192,8 @@ resource "aws_ssm_parameter" "connection" {
         cidrBlock        = subnet.cidrBlock
       }
     ]
-    vpcID = local.vpc_id
+    volumeKMSKeyID = var.volume-kms-key-id
+    vpcID          = local.vpc_id
   })
 
   tags = merge(var.tags, { "depot-connection" = var.connection-id })

--- a/main.tf
+++ b/main.tf
@@ -180,7 +180,7 @@ resource "aws_security_group" "instance-default" {
 
 resource "aws_ssm_parameter" "connection" {
   name   = "/depot/connection/${var.connection-id}"
-  type   = var.connection-parameter-type
+  type   = "SecureString"
   key_id = var.connection-parameter-kms-key-id
   value = jsonencode({
     accountID                = local.account_id

--- a/main.tf
+++ b/main.tf
@@ -97,16 +97,6 @@ resource "aws_route_table_association" "public" {
   route_table_id = aws_route_table.public[0].id
 }
 
-resource "aws_flow_log" "vpc" {
-  count                = var.flow-log-destination-arn == null ? 0 : 1
-  vpc_id               = local.vpc_id
-  traffic_type         = var.flow-log-traffic-type
-  log_destination      = var.flow-log-destination-arn
-  log_destination_type = var.flow-log-destination-type
-  iam_role_arn         = var.flow-log-iam-role-arn
-  tags                 = merge(var.tags, { Name = "depot-connection-${var.connection-id}" })
-}
-
 # Instance IAM
 
 resource "aws_iam_role" "instance" {
@@ -190,6 +180,7 @@ resource "aws_ssm_parameter" "connection" {
     controllerRoleARN        = aws_iam_role.controller.arn
     instanceProfileARN       = aws_iam_instance_profile.instance.arn
     instanceRoleARN          = aws_iam_role.instance.arn
+    kmsKeyID                 = var.cache-volume-kms-key-id
     launchTemplateID         = var.launch-template-id
     partition                = local.partition
     region                   = local.region

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,11 +14,33 @@ output "connection-controller-role-arn" {
 }
 
 output "vpc-id" {
-  value       = try(aws_vpc.vpc.id, "")
+  value       = local.vpc_id
   description = "VPC ID"
 }
 
 output "route-table-id" {
-  value       = try(aws_route_table.public.id, "")
+  value       = local.route_table_id
   description = "VPC route table ID"
+}
+
+output "security-groups" {
+  value       = local.security_groups
+  description = "Security groups used by Depot instances"
+}
+
+output "subnets" {
+  value = [
+    for subnet in local.subnets : {
+      id               = subnet.id
+      availabilityZone = subnet.availabilityZone
+      cidrBlock        = subnet.cidrBlock
+    }
+  ]
+  description = "Subnets used by Depot instances"
+}
+
+output "connection-metadata" {
+  value       = jsondecode(aws_ssm_parameter.connection.value)
+  description = "Connection metadata written for Depot"
+  sensitive   = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -102,15 +102,9 @@ variable "connection-parameter-kms-key-id" {
   default     = null
 }
 
-variable "root-volume-kms-key-id" {
+variable "volume-kms-key-id" {
   type        = string
-  description = "KMS key ID or ARN Depot should use for launched instance root volumes"
-  default     = null
-}
-
-variable "cache-volume-kms-key-id" {
-  type        = string
-  description = "KMS key ID or ARN Depot should use for cache/data volumes"
+  description = "KMS key ID or ARN Depot should use for launched instance root and cache/data EBS volumes"
   default     = null
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -96,30 +96,6 @@ variable "default-egress-cidr-blocks" {
   default     = ["0.0.0.0/0"]
 }
 
-variable "flow-log-destination-arn" {
-  type        = string
-  description = "Destination ARN for VPC flow logs. When null, flow logs are not created."
-  default     = null
-}
-
-variable "flow-log-destination-type" {
-  type        = string
-  description = "Destination type for VPC flow logs"
-  default     = "cloud-watch-logs"
-}
-
-variable "flow-log-traffic-type" {
-  type        = string
-  description = "Traffic type captured by VPC flow logs"
-  default     = "ALL"
-}
-
-variable "flow-log-iam-role-arn" {
-  type        = string
-  description = "IAM role ARN for CloudWatch Logs flow log delivery"
-  default     = null
-}
-
 variable "connection-parameter-kms-key-id" {
   type        = string
   description = "KMS key ID or ARN for the SSM SecureString connection metadata parameter"

--- a/variables.tf
+++ b/variables.tf
@@ -120,17 +120,6 @@ variable "flow-log-iam-role-arn" {
   default     = null
 }
 
-variable "connection-parameter-type" {
-  type        = string
-  description = "SSM parameter type for connection metadata"
-  default     = "String"
-
-  validation {
-    condition     = contains(["String", "SecureString"], var.connection-parameter-type)
-    error_message = "connection-parameter-type must be String or SecureString."
-  }
-}
-
 variable "connection-parameter-kms-key-id" {
   type        = string
   description = "KMS key ID or ARN for the SSM SecureString connection metadata parameter"

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,8 @@ variable "connection-id" {
 
 variable "subnets" {
   type        = list(object({ availability-zone = string, cidr-block = string }))
-  description = "Subnets to use for the VPC"
+  description = "Subnets to create in the module-managed VPC"
+  default     = []
 }
 
 variable "controller-role-arn" {
@@ -29,8 +30,127 @@ variable "cidr-block" {
   default     = "10.0.0.0/16"
 }
 
+variable "vpc-id" {
+  type        = string
+  description = "Existing VPC ID to use instead of creating a VPC"
+  default     = null
+}
+
+variable "existing-subnets" {
+  type        = list(object({ id = string, availability-zone = string, cidr-block = string }))
+  description = "Existing subnets to use instead of creating subnets"
+  default     = []
+}
+
+variable "route-table-id" {
+  type        = string
+  description = "Existing route table ID to include in Depot connection metadata"
+  default     = null
+}
+
+variable "create-internet-gateway" {
+  type        = bool
+  description = "Whether to create an internet gateway and default route for module-managed subnets"
+  default     = true
+}
+
+variable "map-public-ip-on-launch" {
+  type        = bool
+  description = "Whether module-created subnets should map public IPs on launch"
+  default     = true
+}
+
+variable "associate-public-ip-address" {
+  type        = bool
+  description = "Whether Depot should associate a public IP address when launching instances"
+  default     = true
+}
+
 variable "allow-ssm-access" {
   type        = bool
   description = "Controls if SSM access should be allowed for the EC2 instances"
   default     = false
+}
+
+variable "security-groups" {
+  type        = object({ buildkit = string, default = string })
+  description = "Existing security groups for Depot instances. When null, the module creates security groups."
+  default     = null
+}
+
+variable "buildkit-ingress-cidr-blocks" {
+  type        = list(string)
+  description = "CIDR blocks allowed to reach BuildKit instances on TCP/443 when the module creates security groups"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "buildkit-egress-cidr-blocks" {
+  type        = list(string)
+  description = "CIDR blocks allowed for BuildKit instance egress when the module creates security groups"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "default-egress-cidr-blocks" {
+  type        = list(string)
+  description = "CIDR blocks allowed for default instance egress when the module creates security groups"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "flow-log-destination-arn" {
+  type        = string
+  description = "Destination ARN for VPC flow logs. When null, flow logs are not created."
+  default     = null
+}
+
+variable "flow-log-destination-type" {
+  type        = string
+  description = "Destination type for VPC flow logs"
+  default     = "cloud-watch-logs"
+}
+
+variable "flow-log-traffic-type" {
+  type        = string
+  description = "Traffic type captured by VPC flow logs"
+  default     = "ALL"
+}
+
+variable "flow-log-iam-role-arn" {
+  type        = string
+  description = "IAM role ARN for CloudWatch Logs flow log delivery"
+  default     = null
+}
+
+variable "connection-parameter-type" {
+  type        = string
+  description = "SSM parameter type for connection metadata"
+  default     = "String"
+
+  validation {
+    condition     = contains(["String", "SecureString"], var.connection-parameter-type)
+    error_message = "connection-parameter-type must be String or SecureString."
+  }
+}
+
+variable "connection-parameter-kms-key-id" {
+  type        = string
+  description = "KMS key ID or ARN for the SSM SecureString connection metadata parameter"
+  default     = null
+}
+
+variable "root-volume-kms-key-id" {
+  type        = string
+  description = "KMS key ID or ARN Depot should use for launched instance root volumes"
+  default     = null
+}
+
+variable "cache-volume-kms-key-id" {
+  type        = string
+  description = "KMS key ID or ARN Depot should use for cache/data volumes"
+  default     = null
+}
+
+variable "launch-template-id" {
+  type        = string
+  description = "Launch template ID Depot should use when launching instances"
+  default     = null
 }


### PR DESCRIPTION
Prepares for govcloud

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes IAM policies, SSM parameter type (String→SecureString), and core networking creation paths; misconfiguration could block instance launches or break existing deployments on upgrade.
> 
> **Overview**
> Extends the **depot/connection/aws** Terraform module so connections work in **GovCloud** and in **customer-managed VPCs**, not only module-created public networking.
> 
> **Partition-aware ARNs** use `data.aws_partition` everywhere IAM/EC2/KMS ARNs are built (including SSM managed policy attachment), so commercial and `aws-us-gov` partitions resolve correctly.
> 
> **Optional BYO networking**: `vpc-id`, `existing-subnets`, `security-groups`, and `route-table-id` skip creating VPC/subnets/IGW/route when supplied; `create-internet-gateway`, `map-public-ip-on-launch`, and `associate-public-ip-address` control public routing and IP behavior for private/GovCloud-style setups.
> 
> **Connection metadata** moves to SSM **SecureString** (optional `connection-parameter-kms-key-id`) and adds fields such as `partition`, `controllerRoleARN`, `associatePublicIPAddress`, `launchTemplateID`, and `volumeKMSKeyID`. Controller IAM gains launch-template describe/run permissions and conditional **KMS** grants when volume or parameter keys are set.
> 
> **Docs/outputs**: README adds a private-networking example; new outputs expose subnets, security groups, and sensitive `connection-metadata`. `.idea` is gitignored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88e7f48553a1e6d2029db9bdf5141ca195df4bf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->