### PR TITLE
fix: allow volume tags on create

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -275,6 +275,17 @@ resource "aws_iam_policy" "controller" {
       },
 
       {
+        Action   = ["ec2:CreateTags"],
+        Effect   = "Allow",
+        Resource = "arn:${local.partition}:ec2:*:*:volume/*",
+        Condition = {
+          StringEquals = {
+            "ec2:CreateAction" = ["CreateVolume", "RunInstances"],
+          }
+        }
+      },
+
+      {
         Action   = ["iam:PassRole"]
         Effect   = "Allow"
         Resource = aws_iam_role.instance.arn

--- a/main.tf
+++ b/main.tf
@@ -197,6 +197,7 @@ resource "aws_ssm_parameter" "connection" {
     },
     var.depot-builder-ami-id-x86 == null ? {} : { depotBuilderAMIIdX86 = var.depot-builder-ami-id-x86 },
     var.depot-builder-ami-id-arm == null ? {} : { depotBuilderAMIIdARM = var.depot-builder-ami-id-arm },
+    length(var.extra-tags) == 0 ? {} : { extraTags = var.extra-tags },
     var.launch-template-id == null ? {} : { launchTemplateID = var.launch-template-id },
     var.volume-kms-key-id == null ? {} : { volumeKMSKeyID = var.volume-kms-key-id },
   ))

--- a/variables.tf
+++ b/variables.tf
@@ -114,6 +114,12 @@ variable "launch-template-id" {
   default     = null
 }
 
+variable "extra-tags" {
+  type        = map(string)
+  description = "Additional AWS tags Depot should apply to launched builder instances and root volumes"
+  default     = {}
+}
+
 variable "depot-bootstrap-mode" {
   type        = string
   description = "Depot builder bootstrap mode. Use userdata for the default cloud-init bootstrap or ami-tags for builders pre-baked into the AMI."


### PR DESCRIPTION
## Summary

Connection metadata can now include extra-tags, which are serialized as extraTags for managed builders. The controller role also keeps the tag-on-create volume permission so EBS tags can be applied during CreateVolume and RunInstances without broad post-create tagging access.

Together with the API and cloudd changes, this gives customers a controlled extraTags field instead of requiring launch-template tag specifications to carry Depot-owned tags.

## Verification

- terraform fmt main.tf variables.tf
- git diff --check
- Attempted terraform validate previously; local AWS provider plugin failed during schema startup before validation could run