### PR TITLE
Default to managed v2 builder AMIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ The connection metadata includes `volumeKMSKeyID` and `launchTemplateID` when `v
 
 ## Custom builder AMIs
 
+Depot uses the managed v2 AMIs below by default when the module runs in a
+supported region:
+
+| Partition    | Region          | x86 AMI                 | ARM AMI                 |
+| ------------ | --------------- | ----------------------- | ----------------------- |
+| AWS          | `us-east-1`     | `ami-02734227bc3c05ff2` | `ami-0642d370cc4e10bf5` |
+| AWS          | `eu-central-1`  | `ami-0db3a18b0308eb2e6` | `ami-09b13e404a4266f15` |
+| AWS GovCloud | `us-gov-west-1` | `ami-08b6735dd90919e0d` | `ami-01a3efccc8df82310` |
+| AWS GovCloud | `us-gov-east-1` | `ami-050d7f1ce5827e823` | `ami-0fb71d816ee16019c` |
+
+Override either regional default when using custom builder AMIs:
+
 ```tf
 module "connection" {
   source = "depot/connection/aws"
@@ -64,7 +76,8 @@ module "connection" {
 }
 ```
 
-Provide one AMI ID per architecture that the connection should run.
+In unsupported regions, provide one AMI ID per architecture that the connection
+should run.
 
 <!-- BEGIN_TF_DOCS -->
 
@@ -79,8 +92,8 @@ Provide one AMI ID per architecture that the connection should run.
 | <a name="input_cidr-block"></a> [cidr-block](#input_cidr-block)                                                                | VPC CIDR block                                                                           | `string`                                                                         | `"10.0.0.0/16"` |    no    |
 | <a name="input_connection-parameter-kms-key-id"></a> [connection-parameter-kms-key-id](#input_connection-parameter-kms-key-id) | KMS key ID or ARN for the SSM SecureString connection metadata parameter                 | `string`                                                                         | `null`          |    no    |
 | <a name="input_create-internet-gateway"></a> [create-internet-gateway](#input_create-internet-gateway)                         | Whether to create public internet routing for module-managed subnets                     | `bool`                                                                           | `true`          |    no    |
-| <a name="input_depot-builder-ami-id-arm"></a> [depot-builder-ami-id-arm](#input_depot-builder-ami-id-arm)                      | AMI ID Depot should use for ARM builders                                                 | `string`                                                                         | `null`          |    no    |
-| <a name="input_depot-builder-ami-id-x86"></a> [depot-builder-ami-id-x86](#input_depot-builder-ami-id-x86)                      | AMI ID Depot should use for x86 builders                                                 | `string`                                                                         | `null`          |    no    |
+| <a name="input_depot-builder-ami-id-arm"></a> [depot-builder-ami-id-arm](#input_depot-builder-ami-id-arm)                      | Override the regional managed v2 AMI Depot should use for ARM builders                   | `string`                                                                         | `null`          |    no    |
+| <a name="input_depot-builder-ami-id-x86"></a> [depot-builder-ami-id-x86](#input_depot-builder-ami-id-x86)                      | Override the regional managed v2 AMI Depot should use for x86 builders                   | `string`                                                                         | `null`          |    no    |
 | <a name="input_existing-subnets"></a> [existing-subnets](#input_existing-subnets)                                              | Existing subnets to use instead of creating subnets                                      | `list(object({ id = string, availability-zone = string, cidr-block = string }))` | `[]`            |    no    |
 | <a name="input_launch-template-id"></a> [launch-template-id](#input_launch-template-id)                                        | Launch template ID Depot should use when launching instances                             | `string`                                                                         | `null`          |    no    |
 | <a name="input_security-groups"></a> [security-groups](#input_security-groups)                                                 | Existing security groups for Depot instances                                             | `object({ buildkit = string, default = string })`                                | `null`          |    no    |

--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,37 @@ locals {
   account_id = data.aws_caller_identity.current.account_id
   region     = data.aws_region.current.region
 
+  depot_builder_amis = {
+    aws = {
+      us-east-1 = {
+        x86 = "ami-02734227bc3c05ff2"
+        arm = "ami-0642d370cc4e10bf5"
+      }
+      eu-central-1 = {
+        x86 = "ami-0db3a18b0308eb2e6"
+        arm = "ami-09b13e404a4266f15"
+      }
+    }
+    aws-us-gov = {
+      us-gov-west-1 = {
+        x86 = "ami-08b6735dd90919e0d"
+        arm = "ami-01a3efccc8df82310"
+      }
+      us-gov-east-1 = {
+        x86 = "ami-050d7f1ce5827e823"
+        arm = "ami-0fb71d816ee16019c"
+      }
+    }
+  }
+
+  regional_depot_builder_amis = lookup(
+    lookup(local.depot_builder_amis, local.partition, {}),
+    local.region,
+    {},
+  )
+  depot_builder_ami_id_x86 = var.depot-builder-ami-id-x86 != null ? var.depot-builder-ami-id-x86 : lookup(local.regional_depot_builder_amis, "x86", null)
+  depot_builder_ami_id_arm = var.depot-builder-ami-id-arm != null ? var.depot-builder-ami-id-arm : lookup(local.regional_depot_builder_amis, "arm", null)
+
   vpc_id         = local.create_vpc ? aws_vpc.vpc[0].id : var.vpc-id
   route_table_id = local.create_public_route ? aws_route_table.public[0].id : var.route-table-id
 
@@ -194,8 +225,8 @@ resource "aws_ssm_parameter" "connection" {
       ]
       vpcID = local.vpc_id
     },
-    var.depot-builder-ami-id-x86 == null ? {} : { depotBuilderAMIIdX86 = var.depot-builder-ami-id-x86 },
-    var.depot-builder-ami-id-arm == null ? {} : { depotBuilderAMIIdARM = var.depot-builder-ami-id-arm },
+    local.depot_builder_ami_id_x86 == null ? {} : { depotBuilderAMIIdX86 = local.depot_builder_ami_id_x86 },
+    local.depot_builder_ami_id_arm == null ? {} : { depotBuilderAMIIdARM = local.depot_builder_ami_id_arm },
     length(var.extra-tags) == 0 ? {} : { extraTags = var.extra-tags },
     var.launch-template-id == null ? {} : { launchTemplateID = var.launch-template-id },
     var.volume-kms-key-id == null ? {} : { volumeKMSKeyID = var.volume-kms-key-id },

--- a/variables.tf
+++ b/variables.tf
@@ -122,12 +122,12 @@ variable "extra-tags" {
 
 variable "depot-builder-ami-id-x86" {
   type        = string
-  description = "AMI ID Depot should use for x86 builders"
+  description = "Override the regional managed v2 AMI Depot should use for x86 builders"
   default     = null
 }
 
 variable "depot-builder-ami-id-arm" {
   type        = string
-  description = "AMI ID Depot should use for ARM builders"
+  description = "Override the regional managed v2 AMI Depot should use for ARM builders"
   default     = null
 }


### PR DESCRIPTION
## What changed

- add managed-v2 x86 and ARM AMI defaults for `us-east-1` and `eu-central-1`
- add managed-v2 x86 and ARM AMI defaults for `us-gov-west-1` and `us-gov-east-1`
- select defaults from the active AWS partition and region
- retain `depot-builder-ami-id-x86` and `depot-builder-ami-id-arm` as explicit overrides
- document the regional AMI IDs and unsupported-region behavior

## Why

Connections using `useNewInfra` require pre-baked managed-v2 builder AMIs. Previously the module omitted both AMI fields unless every caller supplied custom values.

## Impact

Connections in the four supported regions automatically write the appropriate managed-v2 AMI IDs into their connection metadata. Existing explicit AMI values continue to take precedence. Other regions retain the previous behavior and require explicit AMI IDs.

## Validation

- cross-checked all eight AMI IDs against the successful machine-images build run
- `terraform fmt -check -diff`
- `terraform validate`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which AMI IDs are written into connection metadata for deployments that previously omitted them, affecting EC2 builder launches in supported regions; overrides and unsupported regions behave as before.
> 
> **Overview**
> **Connections in four supported regions now get managed v2 x86/ARM builder AMI IDs in SSM connection metadata without setting module variables.**
> 
> `main.tf` adds a partition/region AMI map (`aws`: `us-east-1`, `eu-central-1`; `aws-us-gov`: `us-gov-west-1`, `us-gov-east-1`) and resolves `depot_builder_ami_id_x86` / `depot_builder_ami_id_arm` from the current partition and region when `depot-builder-ami-id-x86` / `depot-builder-ami-id-arm` are unset. Explicit inputs still override. Unsupported partition/region pairs keep omitting AMI fields unless callers set them.
> 
> **README** documents the default AMI table, frames the inputs as overrides, and notes unsupported-region behavior. Variable descriptions match that override semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 889a1b45344c4a35eb2aa878bcce12910d9a8039. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->